### PR TITLE
Fix arguments and return type resolution for delegates

### DIFF
--- a/src/RuntimeCompiler/RuntimeCompiler.Tests/CompilerDelegateTests.cs
+++ b/src/RuntimeCompiler/RuntimeCompiler.Tests/CompilerDelegateTests.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace RuntimeCompiler.Tests
+{
+    [TestClass]
+    public class CompilerDelegateTests
+    {
+        [TestMethod]
+        public void Custom_delegate_can_be_executed()
+        {
+            // Arrange
+            var expectedResult = "someValue";
+
+            // Act
+            var func = Compiler.CompileDelegate<MyDelegate>("return value;", new[] { "value" });
+            var actualResult = func(expectedResult);
+
+            // Assert
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+
+        delegate string MyDelegate(string value);
+    }
+}

--- a/src/RuntimeCompiler/RuntimeCompiler.Tests/CompilerDelegateTests.cs
+++ b/src/RuntimeCompiler/RuntimeCompiler.Tests/CompilerDelegateTests.cs
@@ -19,7 +19,6 @@ namespace RuntimeCompiler.Tests
             Assert.AreEqual(expectedResult, actualResult);
         }
 
-
         delegate string MyDelegate(string value);
     }
 }

--- a/src/RuntimeCompiler/RuntimeCompiler/Compiler.cs
+++ b/src/RuntimeCompiler/RuntimeCompiler/Compiler.cs
@@ -688,17 +688,13 @@ namespace RuntimeCompiler
 
         private static string GetFullTypeName(Type type) => type.FullName?.Replace('+', '.') ?? throw new ArgumentException($"The FullName of {type} must not be null.", nameof(type));
 
-        private static IEnumerable<string> GetFullTypeNames(params Type[] types)
+        private static IEnumerable<string> GetFullTypeNames(IEnumerable<Type> types)
             => types.Select(GetFullTypeName);
 
-        private static (Type[] parameters, Type result) GetParametersAndResultTypes(Type delegateType)
+        private static (IEnumerable<Type> parameters, Type result) GetParametersAndResultTypes(Type delegateType)
         {
-            var isAction = delegateType.FullName?.StartsWith("System.Action") ?? throw new ArgumentException($"The FullName of {delegateType} must not be null.", nameof(delegateType));
-
-            if (isAction)
-                return (delegateType.GenericTypeArguments, typeof(void));
-
-            return (delegateType.GenericTypeArguments[..^1], delegateType.GenericTypeArguments[^1]);
+            var invokeMethod = delegateType.GetMethod("Invoke") ?? throw new InvalidOperationException($"Unable to retrieve Invoke method of the type '{delegateType}'. Make sure the type is a delegate.");            
+            return (invokeMethod.GetParameters().Select(x => x.ParameterType), invokeMethod.ReturnType);
         }
     }
 }

--- a/src/RuntimeCompiler/RuntimeCompiler/RuntimeCompiler.csproj
+++ b/src/RuntimeCompiler/RuntimeCompiler/RuntimeCompiler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
When passing a custom delegate type to `Compiler.CompileDelegate` the method `GetParametersAndResultTypes` fails because it only expects `Action<>` or `Func<>`.

This change allows to pass any type of delegate.